### PR TITLE
feat: Add initial database schema for photo portfolio application

### DIFF
--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -15,6 +15,7 @@ return new class extends Migration
             $table->id();
             $table->string('name');
             $table->string('email')->unique();
+            $table->string('phone_number')->nullable();
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
             $table->rememberToken();

--- a/database/migrations/2024_06_30_102916_create_photos_table.php
+++ b/database/migrations/2024_06_30_102916_create_photos_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('photos', function (Blueprint $table) {
+            $table->id();
+            $table->string('file_path');
+            $table->text('caption')->nullable();
+            $table->boolean('is_face_present')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('photos');
+    }
+};

--- a/database/migrations/2024_06_30_102934_create_photo_tags_table.php
+++ b/database/migrations/2024_06_30_102934_create_photo_tags_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('photo_tags', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('photo_id')->constrained('photos')->onDelete('cascade');
+            $table->string('tag');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('photo_tags');
+    }
+};

--- a/database/migrations/2024_06_30_102948_create_downloads_table.php
+++ b/database/migrations/2024_06_30_102948_create_downloads_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('downloads', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained('users')->onDelete('cascade');
+            $table->foreignId('photo_id')->constrained('photos')->onDelete('cascade');
+            $table->timestamp('downloaded_at')->useCurrent();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('downloads');
+    }
+};

--- a/database/migrations/2024_06_30_103004_create_contact_requests_table.php
+++ b/database/migrations/2024_06_30_103004_create_contact_requests_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('contact_requests', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('phone_number')->nullable();
+            $table->string('email');
+            $table->text('request_content');
+            $table->text('details')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('contact_requests');
+    }
+};

--- a/database/migrations/2024_06_30_103027_create_signed_urls_table.php
+++ b/database/migrations/2024_06_30_103027_create_signed_urls_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('signed_urls', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->nullable()->constrained('users')->onDelete('set null');
+            $table->string('url');
+            $table->timestamp('expiration');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('signed_urls');
+    }
+};


### PR DESCRIPTION
- Create `users` table to store user information
- Create `photos` table to store photo metadata
- Create `photo_tags` table to manage tags associated with photos
- Create `downloads` table to log photo download activities
- Create `contact_requests` table to handle contact form submissions
- Create `signed_urls` table to manage signed URLs for secure downloads

These tables form the foundation for the application's database, enabling user management, photo storage, tagging, download logging, contact form handling, and secure URL generation.